### PR TITLE
GCG-19 add kafka sources and the relevant unittest

### DIFF
--- a/DemoTools/DataGenerator/test_config.ini
+++ b/DemoTools/DataGenerator/test_config.ini
@@ -23,3 +23,10 @@ isRegion = yes
 ; OutputFileName is the output stream file name.
 OutputFileName = output_data.csv
 
+[KAFKA_CONF]
+KafkaEnable = no
+BootstrapServer = localhost:9092
+KafkaTopic = aju_data_generator
+KafkaPartition = 0
+
+

--- a/DemoTools/DataGenerator/test_config_kafka.ini
+++ b/DemoTools/DataGenerator/test_config_kafka.ini
@@ -21,12 +21,11 @@ isNation = Yes
 isRegion = yes
 
 ; OutputFileName is the output stream file name.
-OutputFileName = output_data.csv
+OutputFileName = test_output_data.csv
 
 [KAFKA_CONF]
-KafkaEnable = no
+KafkaEnable = yes
 BootstrapServer = localhost:9092
-KafkaTopic = aju_data_generator
-
+KafkaTopic = test_aju_data_generator
 
 


### PR DESCRIPTION
Use confluent_kafka as the kafka producer and consumer.
The unittest show that the kafka produced and consumed data files are the same as the written output file.

Unittest Coverage:
`DataGenerator.py    ->    96% lines covered`